### PR TITLE
Released version 0.3 to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chromer
 Title: Interface to Chromosome Counts Database API
-Version: 0.1.3
-Date: 2022-10-24
+Version: 0.2
+Date: 2022-10-26
 Authors@R: c(
     person("Matthew", "Pennell", role = "aut", email = "mwpennell@gmail.com",
            comment = c(ORCID = "0000-0002-2886-3970")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chromer
 Title: Interface to Chromosome Counts Database API
-Version: 0.2
-Date: 2022-10-26
+Version: 0.3
+Date: 2022-10-27
 Authors@R: c(
     person("Matthew", "Pennell", role = "aut", email = "mwpennell@gmail.com",
            comment = c(ORCID = "0000-0002-2886-3970")),
@@ -12,7 +12,7 @@ Authors@R: c(
   )
 Description: A programmatic interface to the Chromosome Counts Database
     (<http://ccdb.tau.ac.il/>), Rice et al. (2014) <doi:10.1111/nph.13191>.
-    This package is part of the rOpenSci suite (<https://ropensci.org>).
+    This package is part of the 'ROpenSci' suite (<https://ropensci.org>).
 Depends:
     R (>= 2.15)
 Imports:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,6 @@
 ### The MIT License (MIT)
 
-Copyright (c) 2022 [Matthew Pennell](https://mwpennell.github.io/),
-[Paula Andrea Martinez](https://twitter.com/orchid00), and [Karl W
-Broman](https://github.com/kbroman)
+Copyright (c) 2022 Matthew Pennell, Paula Andrea Martinez, and Karl W Broman
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ chromer 0.3
 
 ### MINOR CHANGES
 
-* New maintainer, Karl Broman <https://kbroman.org>
+* New maintainer, [Karl Broman](https://kbroman.org)
 
 * Changed software license, CC0 -> MIT
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ chromer 0.3
 
 ### MINOR CHANGES
 
-* New maintainer, Karl Broman <kbroman.org>
+* New maintainer, Karl Broman <https://kbroman.org>
 
 * Changed software license, CC0 -> MIT
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-chromer 0.2
+chromer 0.3
 =============
 
 ### MINOR CHANGES

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-chromer 0.1.3
+chromer 0.2
 =============
 
 ### MINOR CHANGES

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/kbroman/chromer/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/kbroman/chromer/actions/workflows/R-CMD-check.yaml)
+[![CRAN status](https://www.r-pkg.org/badges/version/chromer)](https://CRAN.R-project.org/package=chromer)
 <!-- badges: end -->
 
 # chromer <img alt="chromer logo" src="man/figures/logo.png" align="right"/>

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ summarize_counts(sol_gen)
 ## Meta
 
 * Please [report any issues or bugs](https://github.com/ropensci/chromer/issues).
-* License: [MIT](LICENSE.md)
+* License: [MIT](https://github.com/ropensci/chromer/blob/master/LICENSE.md)
 * Get citation information for `chromer` in R doing `citation(package = "chromer")`
-* Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
+* Please note that this project is released with a [Contributor Code of Conduct](https://github.com/ropensci/chromer/blob/master/CONDUCT.md).
+  By participating in this project you agree to abide by its terms.
 
 [![ropensci footer](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "codeRepository": "https://github.com/kbroman/chromer",
   "issueTracker": "https://github.com/ropensci/chromer/issues/new",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.1.3",
+  "version": "0.2",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -123,7 +123,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "39.45KB",
+  "fileSize": "39.434KB",
   "relatedLink": "https://docs.ropensci.org/chromer/",
   "releaseNotes": "https://github.com/kbroman/chromer/blob/master/NEWS.md",
   "readme": "https://github.com/kbroman/chromer/blob/master/README.md",


### PR DESCRIPTION
- needed quotes around ROpenSci in the package description
- linked to LICENSE.md and CONDUCT.md in README.md file needed to be full web URLs since those files aren't included in the package sent to CRAN.