### PR TITLE
API url has changed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chromer
 Title: Interface to Chromosome Counts Database API
-Version: 0.6
-Date: 2023-09-21
+Version: 0.7-1
+Date: 2024-03-26
 Authors@R: c(
     person("Matthew", "Pennell", role = "aut", email = "mwpennell@gmail.com",
            comment = c(ORCID = "0000-0002-2886-3970")),
@@ -11,7 +11,7 @@ Authors@R: c(
            comment=c(ORCID = "0000-0002-4914-6671"))
   )
 Description: A programmatic interface to the Chromosome Counts Database
-    (<https://ccdb.tau.ac.il/>), Rice et al. (2014) <doi:10.1111/nph.13191>.
+    (<https://taux.evolseq.net/CCDB_web/>), Rice et al. (2014) <doi:10.1111/nph.13191>.
     This package is part of the 'ROpenSci' suite (<https://ropensci.org>).
 Depends:
     R (>= 2.15)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chromer
 Title: Interface to Chromosome Counts Database API
-Version: 0.7-1
+Version: 0.8
 Date: 2024-03-26
 Authors@R: c(
     person("Matthew", "Pennell", role = "aut", email = "mwpennell@gmail.com",
@@ -26,5 +26,5 @@ Suggests:
 URL: https://docs.ropensci.org/chromer/, https://github.com/ropensci/chromer
 BugReports: https://github.com/ropensci/chromer/issues
 License: MIT + file LICENSE
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
-chromer 0.7-1
-=============
+chromer 0.8
+===========
 
 ### Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+chromer 0.7-1
+=============
+
+### Minor changes
+
+* API has moved to a new site, <https://taux.evolseq.net/CCDB_web/services/>
+
+
 chromer 0.6
 =============
 
@@ -20,7 +28,7 @@ chromer 0.4
 ### Minor changes
 
 * Skip the tests on CRAN, so that it doesn't give errors if the
-  API to <https://ccdb.tau.ac.il/> is down.
+  API is down.
 
 * Added internal function to check if CCDB is down, and skip the tests
   when that's true.

--- a/R/ccdb_down.R
+++ b/R/ccdb_down.R
@@ -1,5 +1,5 @@
 # taken from https://stackoverflow.com/a/60627969
-ccdb_down <- function(url_in="https://ccdb.tau.ac.il",timeout=2){
+ccdb_down <- function(url_in="https://taux.evolseq.net/CCDB_web/services/",timeout=2){
   con <- url(url_in)
   check <- suppressWarnings(try(open.connection(con,open="rt",timeout=timeout),silent=TRUE)[1])
   suppressWarnings(try(close.connection(con),silent=TRUE))

--- a/R/counts.R
+++ b/R/counts.R
@@ -68,7 +68,7 @@ chrom_counts_single <- function(taxa, rank, out, foptions){
     if (rank == "species")
         taxa <- species_API(taxa)
 
-    url <- paste0("https://ccdb.tau.ac.il/services/",
+    url <- paste0("https://taux.evolseq.net/CCDB_web/services/",
                   out,"/?", rank,"=",taxa,"&format=","json")
     counts_call <- GET(url, foptions)
     stop_for_status(counts_call)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 # chromer <img alt="chromer logo" src="man/figures/logo.png" align="right"/>
 
 This package provides programmatic access to the [Chromosome Counts
-Database (CCDB)](https://ccdb.tau.ac.il/home/)
-[API](https://ccdb.tau.ac.il/services/). The CCDB is a community
+Database (CCDB)](https://taux.evolseq.net/CCDB_web)
+[API](https://taux.evolseq.net/CCDB_web/services/). The CCDB is a community
 resource for plant chromosome numbers. For more details on the
 database, see the associated publication by Rice et al. (2014)
 <doi:10.1111/nph.13191> in *New Phytologist*.

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,19 +2,19 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "chromer",
-  "description": "A programmatic interface to the Chromosome Counts Database (<https://ccdb.tau.ac.il/>), Rice et al. (2014) <doi:10.1111/nph.13191>. This package is part of the 'ROpenSci' suite (<https://ropensci.org>).",
+  "description": "A programmatic interface to the Chromosome Counts Database (<https://taux.evolseq.net/CCDB_web/>), Rice et al. (2014) <doi:10.1111/nph.13191>. This package is part of the 'ROpenSci' suite (<https://ropensci.org>).",
   "name": "chromer: Interface to Chromosome Counts Database API",
   "relatedLink": ["https://docs.ropensci.org/chromer/", "https://CRAN.R-project.org/package=chromer"],
   "codeRepository": "https://github.com/ropensci/chromer",
   "issueTracker": "https://github.com/ropensci/chromer/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.6",
+  "version": "0.8",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.3.1 (2023-06-16)",
+  "runtimePlatform": "R version 4.3.3 (2024-02-29)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -130,7 +130,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "41.499KB",
+  "fileSize": "41.652KB",
   "releaseNotes": "https://github.com/ropensci/chromer/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/chromer/blob/master/README.md",
   "contIntegration": "https://github.com/ropensci/chromer/actions/workflows/R-CMD-check.yaml",

--- a/tests/testthat/test-data-summary.R
+++ b/tests/testthat/test-data-summary.R
@@ -3,7 +3,7 @@ context("Testing data processing and summary")
 test_that("data processing and summary", {
 
     skip_if_offline()    # offline or on CRAN
-    skip_if(ccdb_down()) # ccdb.tau.ac.il is down
+    skip_if(ccdb_down()) # ccdb api is down
 
     cp <- chrom_counts("Castilleja", "genus")
     sum_res <- summarize_counts(cp)

--- a/tests/testthat/test-rank-query.R
+++ b/tests/testthat/test-rank-query.R
@@ -3,7 +3,7 @@ context("Testing rank-based query")
 test_that("Rank-based query", {
 
     skip_if_offline()    # offline or on CRAN
-    skip_if(ccdb_down()) # ccdb.tau.ac.il is down
+    skip_if(ccdb_down()) # ccdb api is down
 
     ## Query for genus Lachemilla for testing purposes
     cp <- chrom_counts(taxa="Lachemilla", rank="genus", full=FALSE)


### PR DESCRIPTION
The Chromosome Counts database API had been down, but it is back up with a new URL, <https://taux.evolseq.net/CCDB_web/services/>. 